### PR TITLE
## 업로드 페이지에서 이미지와 코멘트까지 같이 전송하도록 함

### DIFF
--- a/backend/src/routes/api/File/index.ts
+++ b/backend/src/routes/api/File/index.ts
@@ -56,11 +56,14 @@ export default async function (fastify: FastifyInstance) {
     fileresult.push(fileid);
     reply.send({files: fileresult, filetype});
   });
+
   fastify.delete("/:fileid", async (req: FastifyRequest<{Params: {fileid: string}}>, reply: FastifyReply) => {
+    console.log(req.params)
     const {fileid} = req.params;
     const result = await deleteFile(fileid);
     reply.send(result);
   });
+
   async function makefile(userid: any, part: any, filename: string, filetype: string) {
     const mimetype = part.mimetype;
     const fileid = generatedUUID();

--- a/frontend/src/data/upload/axios.tsx
+++ b/frontend/src/data/upload/axios.tsx
@@ -11,14 +11,14 @@ export async function getAudioFile(userid: any) {
   }
 }
 
+  // 삭제하려는 fileid와 그 요청을 보내는 user의 id를 받아서 서버로 요청을 보내는 함수.
 export function deleteAudioFile(audioFile: any, loginUser: any){
   try{
-      const res = api.post(`/file`, audioFile.fileid)
+      const res = api.delete(`/file/${audioFile.fileid}`)
       return res;
   }catch(error){
     throw new Error("Failed to delete audio files");
   }
-  // 삭제하려는 fileid와 그 요청을 보내는 user의 id를 받아서 서버로 요청을 보내는 함수.
 }
 
 // 오디오 파일 서버에 보내기 및 에러 처리


### PR DESCRIPTION
## PR 내용
- 업로드 페이지에서 이미지와 코멘트까지 같이 전송하도록 함
- 유저의 audio리스트도 같이 조정함
## 에로사항
서버에서 post요청으로 코멘트와 이미지를 같이 받도록 수정바람.
- get요청을 오면 코멘트와 이미지도 같이 보내도록 수정해주셈.
- delete도 같이 수정바람